### PR TITLE
opendkim.conf.KeyTables breaks config

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 opendkim:
   conf:
     UserID: "opendkim:opendkim"
-    KeyTables: "/etc/opendkim/KeyTable"
+    KeyTable: "/etc/opendkim/KeyTable"
     SigningTable: "/etc/opendkim/SigningTable"
     PidFile: "/var/run/opendkim/opendkim.pid"
     Mode: "v"


### PR DESCRIPTION
opendkim.conf.KeyTables breaks configuration file.
The right config switch is "KeyTable" (without trailing 's')
